### PR TITLE
Handle CRLF line endings.

### DIFF
--- a/lcat/src/rainbow.rs
+++ b/lcat/src/rainbow.rs
@@ -106,13 +106,13 @@ impl Rainbow {
             out.write_all(b"\x1B")?;
             return Ok(true);
         }
-        if grapheme == "\n" {
+        if grapheme == "\n" || grapheme == "\r\n" {
             self.reset_col();
             self.step_row(1);
             if self.invert {
                 out.write_all(b"\x1B[49m")?;
             }
-            out.write_all(b"\n")?;
+            out.write_all(grapheme.as_bytes())?;
             return Ok(false);
         }
 


### PR DESCRIPTION
Screenshot using current lcat:
![lcat-crlf-1](https://user-images.githubusercontent.com/56464409/171034455-59066ba1-048a-4714-b874-0c51e553c4a2.png)
