### PR TITLE
Add support for non-truecolor terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ansi_colours"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14eec43e0298190790f41679fe69ef7a829d2a2ddd78c8c00339e84710e435fe"
+dependencies = [
+ "rgb",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +110,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "bytes"
@@ -469,6 +484,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "lcat"
 version = "0.7.15"
 dependencies = [
+ "ansi_colours",
  "bstr",
  "clap",
  "colorgrad",
@@ -649,6 +665,15 @@ name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"

--- a/lcat/Cargo.toml
+++ b/lcat/Cargo.toml
@@ -13,6 +13,7 @@ description = "Another lolcat in rust! Full unicode support, escapes for ANSI es
 default = ["clap"]
 
 [dependencies]
+ansi_colours = "1.2.3"
 bstr = "1.12.0"
 clap = { version = "4.5.36", features = ["derive", "wrap_help"], optional = true }
 colorgrad = { version = "0.7.1", default-features = false, features = ["preset"] }

--- a/lcat/src/main.rs
+++ b/lcat/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 
 use std::{
+    env,
     fs::File,
     io::{self, BufReader},
     path::PathBuf,
@@ -28,11 +29,13 @@ fn main() -> Result<(), io::Error> {
 
     let mut rainbow: Rainbow = opt.rainbow.into();
     let mut stdout = io::stdout().lock();
+    let is_truecolor = env::var("COLORTERM").is_ok_and(|val| val == "truecolor" || val == "24bit");
 
     if opt.help {
         rainbow.colorize_str(
             &Cmdline::command().render_help().ansi().to_string(),
             &mut stdout,
+            is_truecolor,
         )?;
         return Ok(());
     }
@@ -40,11 +43,11 @@ fn main() -> Result<(), io::Error> {
     for path in opt.files {
         if path == PathBuf::from("-") {
             let mut stdin = io::stdin().lock();
-            rainbow.colorize_read(&mut stdin, &mut stdout)?;
+            rainbow.colorize_read(&mut stdin, &mut stdout, is_truecolor)?;
         } else {
             let f = File::open(path).unwrap();
             let mut b = BufReader::new(f);
-            rainbow.colorize_read(&mut b, &mut stdout)?;
+            rainbow.colorize_read(&mut b, &mut stdout, is_truecolor)?;
         }
     }
 

--- a/lcat/src/rainbow_cmd.rs
+++ b/lcat/src/rainbow_cmd.rs
@@ -1,13 +1,12 @@
 use clap::{Parser, ValueEnum};
 
-use crate::{Ansi256Grad, Grad, HsvGrad, Rainbow};
+use crate::{Ansi256RainbowGrad, Ansi256SinebowGrad, Gradient, HsvGrad, Rainbow};
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum RainbowStyle {
     Rainbow,
     Sinebow,
     OkHsv,
-    Ansi,
 }
 
 #[derive(Debug, Parser)]
@@ -61,11 +60,19 @@ impl From<RainbowCmd> for Rainbow {
 
         let start = cmd.hue.map_or_else(fastrand::f32, |hue| hue / 360.);
 
-        let grad: Box<dyn Grad> = match cmd.style {
-            RainbowStyle::Rainbow => Box::new(colorgrad::preset::rainbow()),
-            RainbowStyle::Sinebow => Box::new(colorgrad::preset::sinebow()),
-            RainbowStyle::OkHsv => Box::new(HsvGrad {}),
-            RainbowStyle::Ansi => Box::new(Ansi256Grad {}),
+        let grad = match cmd.style {
+            RainbowStyle::Rainbow => Gradient {
+                true_color: Box::new(colorgrad::preset::rainbow()),
+                ansi_fallback: Some(Box::new(Ansi256RainbowGrad {})),
+            },
+            RainbowStyle::Sinebow => Gradient {
+                true_color: Box::new(colorgrad::preset::sinebow()),
+                ansi_fallback: Some(Box::new(Ansi256SinebowGrad {})),
+            },
+            RainbowStyle::OkHsv => Gradient {
+                true_color: Box::new(HsvGrad {}),
+                ansi_fallback: None,
+            },
         };
 
         Self::new(grad, start, shift_col, shift_row, cmd.invert)

--- a/lcat/src/rainbow_cmd.rs
+++ b/lcat/src/rainbow_cmd.rs
@@ -1,12 +1,13 @@
 use clap::{Parser, ValueEnum};
 
-use crate::{Grad, HsvGrad, Rainbow};
+use crate::{Ansi256Grad, Grad, HsvGrad, Rainbow};
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum RainbowStyle {
     Rainbow,
     Sinebow,
     OkHsv,
+    Ansi,
 }
 
 #[derive(Debug, Parser)]
@@ -64,6 +65,7 @@ impl From<RainbowCmd> for Rainbow {
             RainbowStyle::Rainbow => Box::new(colorgrad::preset::rainbow()),
             RainbowStyle::Sinebow => Box::new(colorgrad::preset::sinebow()),
             RainbowStyle::OkHsv => Box::new(HsvGrad {}),
+            RainbowStyle::Ansi => Box::new(Ansi256Grad {}),
         };
 
         Self::new(grad, start, shift_col, shift_row, cmd.invert)

--- a/lcowsay/src/main.rs
+++ b/lcowsay/src/main.rs
@@ -1,6 +1,9 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 
-use std::io::{self, Read, Write};
+use std::{
+    env,
+    io::{self, Read, Write},
+};
 
 use clap::Parser;
 use lcat::{Rainbow, RainbowCmd};
@@ -31,6 +34,7 @@ fn main() -> io::Result<()> {
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
+    let is_truecolor = env::var("COLORTERM").is_ok_and(|val| val == "truecolor" || val == "24bit");
 
     let cow = Cow::new(opt.shape, text, opt.max_length);
     let cow = format!("{cow}\n");
@@ -38,7 +42,7 @@ fn main() -> io::Result<()> {
         stdout.write_all(cow.as_bytes())?;
     } else {
         let mut rainbow: Rainbow = opt.rainbow.into();
-        rainbow.colorize_str(&cow, &mut stdout)?;
+        rainbow.colorize_str(&cow, &mut stdout, is_truecolor)?;
     }
     stdout.flush()
 }

--- a/lolcow-fortune/src/main.rs
+++ b/lolcow-fortune/src/main.rs
@@ -183,11 +183,13 @@ fn main() -> Result<(), lolcow_fortune::StrfileError> {
             let cow = format!("{cow}\n");
             let stdout = io::stdout();
             let mut stdout = stdout.lock();
+            let is_truecolor =
+                env::var("COLORTERM").is_ok_and(|val| val == "truecolor" || val == "24bit");
 
             if lolcat {
                 let mut rainbow: Rainbow = rainbow.into();
 
-                rainbow.colorize_str(&cow, &mut stdout)?;
+                rainbow.colorize_str(&cow, &mut stdout, is_truecolor)?;
             } else {
                 stdout.write_all(cow.as_bytes())?;
             }


### PR DESCRIPTION
Currently, using lcat on a non-truecolor terminal such as the MacOS Terminal.app generates mangled output.
Check the `$COLORTERM` env variable and, if the terminal doesn't support truecolor, coerce colors to the closest ANSI-256 color available.
Add specialized fallback gradients for the `rainbow` and `sinebow` options to ensure that ansi colors are evenly spaced.