### PR TITLE
chore: resolve clippy warnings

### DIFF
--- a/lcat/src/rainbow.rs
+++ b/lcat/src/rainbow.rs
@@ -1,11 +1,11 @@
 use std::{
-    io::{prelude::*, Write},
+    io::{Write, prelude::*},
     num::NonZero,
 };
 
 pub use anstyle::Color;
 use anstyle::{Ansi256Color, AnsiColor, RgbColor};
-use bstr::{io::BufReadExt, ByteSlice};
+use bstr::{ByteSlice, io::BufReadExt};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 
@@ -110,23 +110,23 @@ impl Rainbow {
         }
     }
 
-    pub fn step_row(&mut self, n_row: usize) {
+    pub const fn step_row(&mut self, n_row: usize) {
         self.current_row += n_row;
-        self.position += n_row as f32 * self.shift_row;
+        self.position = (n_row as f32).mul_add(self.shift_row, self.position);
     }
 
-    pub fn step_col(&mut self, n_col: usize) {
+    pub const fn step_col(&mut self, n_col: usize) {
         self.current_col += n_col;
-        self.position += n_col as f32 * self.shift_col;
+        self.position = (n_col as f32).mul_add(self.shift_col, self.position);
     }
 
     pub fn reset_row(&mut self) {
-        self.position -= self.current_row as f32 * self.shift_row;
+        self.position = (self.current_row as f32).mul_add(-self.shift_row, self.position);
         self.current_row = 0;
     }
 
     pub fn reset_col(&mut self) {
-        self.position -= self.current_col as f32 * self.shift_col;
+        self.position = (self.current_col as f32).mul_add(-self.shift_col, self.position);
         self.current_col = 0;
     }
 
@@ -444,9 +444,10 @@ mod tests {
         let mut rb_a = create_rb();
         let mut out_a = Vec::new();
         // This should not panic even with invalid UTF-8
-        assert!(rb_a
-            .colorize_read_streaming(&mut cursor, &mut out_a, NonZero::new(3).unwrap())
-            .is_ok());
+        assert!(
+            rb_a.colorize_read_streaming(&mut cursor, &mut out_a, NonZero::new(3).unwrap())
+                .is_ok()
+        );
 
         // The output should contain something (we don't test exact equality since
         // the handling of invalid UTF-8 might differ between methods)

--- a/lcat/src/rainbow_cmd.rs
+++ b/lcat/src/rainbow_cmd.rs
@@ -38,10 +38,10 @@ impl ColorMode {
             None if env::var("TERM_PROGRAM").as_deref() == Ok("Apple_Terminal") => {
                 // macOS 26 and later support Truecolor
                 // 464 is the version used on stable macOS 26.0
-                if let Some(v) = term_program_version() {
-                    if v >= 464 {
-                        return Self::TrueColor;
-                    }
+                if let Some(v) = term_program_version()
+                    && v >= 464
+                {
+                    return Self::TrueColor;
                 }
                 Self::Ansi256
             }

--- a/lolcow-fortune/src/lib.rs
+++ b/lolcow-fortune/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     convert::TryInto,
     fs::File,
-    io::{self, prelude::*, Seek, SeekFrom},
+    io::{self, Seek, SeekFrom, prelude::*},
     num::NonZeroU64,
     path::Path,
     result::Result,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resolve clippy warnings across `lcat` and `lolcow-fortune` by cleaning up imports, simplifying control flow, and tightening numeric updates. No behavior changes.

- **Refactors**
  - `lcat/rainbow`: use `f32::mul_add` for position updates; mark `step_row`/`step_col` as `const`; tidy assert formatting and imports.
  - `lcat/rainbow_cmd`: collapse nested conditionals with an `if let` chain for the Apple Terminal TrueColor check.
  - `lolcow-fortune`: reorder `std::io` imports.

<sup>Written for commit 4f15a4526f6adfd31e020d493de563254bedff2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

